### PR TITLE
Better wording on position and size

### DIFF
--- a/extension/options/manifest.js
+++ b/extension/options/manifest.js
@@ -380,7 +380,7 @@ this.manifest = {
             "group": i18n.get("Preferences"),
             "name": "saveWinPositions",
             "type": "checkbox",
-            "label": i18n.get("Save window positions and sizes")
+            "label": i18n.get("Save window position and size")
         },
         {
             "tab": i18n.get("General"),


### PR DESCRIPTION
I think it is better to use singular form here as one (or many windows) usually have one size and position that is preserved.